### PR TITLE
Add tabindex and aria-label

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         padding-bottom: 0%;
       }
     </style>
-          <section class="hero is-dark">
+    <section class="hero is-dark">
       <div class="hero-body">
         <div tabindex="1" class="container">
           <h1 class="title">

--- a/index.html
+++ b/index.html
@@ -20,51 +20,43 @@
       }
     </style>
           <section class="hero is-dark">
-            <div class="hero-body">
-              <div class="container">
-                <h1 class="title">
-                  <a onclick="window.location.reload()">Libert <i class="fa fa-book"></i></a>
-                </h1>
-                <h2 class="subtitle">
-                  Get e-books for free, easily
-                </h2>
-              </div>
-            </div>
-        </section>
-        <form id="form">
-          <div class="container">
-          <div class="field has-addons has-addons-centered">
-            <div class="control has-icons-left">
-              <input type="text" class="input is-large " id="lolz" placeholder="Type in a book...">
-                  <span class="icon is-small is-left">
-                    <i class="fa fa-book"></i>
-                  </span>
-            </div>
-              <div class="control">
-                <button type="submit" class="button is-primary is-large">
-                  <i class="fa fa-search"></i> 
-                </button>
-              </div>
-            </div>
+      <div class="hero-body">
+        <div tabindex="1" class="container">
+          <h1 class="title">
+            <a onclick="window.location.reload()">Libert <i class="fa fa-book"></i></a>
+          </h1>
+          <h2 class="subtitle">
+            Get e-books for free, easily
+          </h2>
+        </div>
+      </div>
+    </section>
+    <form id="form">
+      <div class="container">
+        <div class="field has-addons has-addons-centered">
+          <div class="control has-icons-left">
+            <input type="text" class="input is-large " id="lolz" placeholder="Type in a book..."><span class="icon is-small is-left"><i class="fa fa-book"></i></span>
           </div>
-        </form>
-
-      <footer class="footer">
-        <div class="container">
-          <div class="content has-text-centered">
-<p>
-              <strong>Libert</strong> made with <i class="fa fa-heart"></i> by <a href="http://jajoosam.tech">Samarth Jajoo</a>. <br> <br> <a href="/disclaimer">Disclaimer</a>.
-            </p>
-            <script src="https://gumroad.com/js/gumroad.js"></script>
-<a class="gumroad-button" href="https://gum.co/jajoosam" target="_blank">Support Libert</a>
-            <p>
-              <a class="icon" href="https://github.com/jajoosam/liberto">
-                <i class="fa fa-github"></i>
-              </a>
-            </p>
+          <div class="control">
+            <button aria-label="Submit Search" type="submit" class="button is-primary is-large">
+              <i class="fa fa-search"></i> 
+            </button>
           </div>
         </div>
-      </footer>
+      </div>
+    </form>
+    <footer class="footer">
+      <div tabindex="0" class="container">
+        <div class="content has-text-centered">
+          <p>
+            <strong>Libert</strong> made with <i aria-label="Love" class="fa fa-heart"></i> by <a href="http://jajoosam.tech">Samarth Jajoo</a>. <br> <br> <a aria-label="Read disclaimer information. Link opens in the same window." href="/disclaimer">Disclaimer</a>.
+          </p>
+          <script src="https://gumroad.com/js/gumroad.js"></script>
+          <a class="gumroad-button" href="https://gum.co/jajoosam" target="_blank">Support Libert</a>
+          <p><a class="icon" href="https://github.com/jajoosam/libert"><i class="fa fa-github"></i></a></p>
+        </div>
+      </div>
+    </footer>
   </body>
     <script>
       document.getElementById("lolz").focus();


### PR DESCRIPTION
## Add focus to pertinent content while tabbing 
I found accessibility issues while navigating the landing page for Libert.ml with a screen reader. The `h1` and `h2` content did not get announced to the user. Since these elements provide helpful content to the user I added `tabindex="1"` so that the header section will be the first section that gains focus when navigating the site via tab key.  

## Add meaningful labels to search user interface
When the user navigates to the search bar, this is a placeholder text that is announced within the input field. But, once the field is filled and focus is moved via tab key to the search icon there is no contextual label to be announce. Originally the icon simply announced "Button" which requires the assumption that it is a "submit" button. To avoid ambiguity I added a meaningful label to the search button - It will now announce "Submit search" when it gains focus. 

## Improve footer, website creator, and disclaimer context
The footer was getting skipped by the screen reader that I used to test this page. There is helpful information about the sites creator, disclaimer, and support located there that would otherwise get missed. To fix this I added a tab index of `tabindex="0"`. This way, the footer will get focus, but after the rest of the page content. I also added a label to the heart icon, that announces it as "Heart", instead of skipping it. I also updated the `aria-label` for the disclaimer link, giving screen reader users more context as to what the link is for, and what happens when they click it.

**Let me know if you have any questions about this pull request!**